### PR TITLE
feat: expand media sections with creative hub and recommendations

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -1,0 +1,45 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@200;400;600;800&display=swap');
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: var(--font-family-sans);
+  scroll-behavior: smooth;
+}
+
+body.theme-dark {
+  background: var(--color-bg);
+  line-height: 1.6;
+  overflow-x: hidden;
+}
+
+img,
+video {
+  max-width: 100%;
+  display: block;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  font-family: inherit;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+}
+
+.section-title {
+  font-size: clamp(1.5rem, 4vw, 2.5rem);
+  text-align: center;
+  margin-bottom: 2rem;
+}

--- a/css/components.css
+++ b/css/components.css
@@ -1,0 +1,386 @@
+.btn {
+  padding: 0.75rem 1.5rem;
+  border-radius: var(--radius);
+  font-size: 1rem;
+  transition: background 0.3s ease, box-shadow 0.3s ease;
+}
+
+.btn--small {
+  padding: 0.5rem 1rem;
+  font-size: 0.85rem;
+}
+
+.btn--pill {
+  border-radius: 9999px;
+}
+
+.btn--glass {
+  background: rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.btn--primary {
+  color: var(--color-accent);
+  box-shadow: 0 0 0.5rem rgba(212, 175, 55, 0.3);
+}
+
+.btn--primary:hover {
+  box-shadow: 0 0 1rem rgba(212, 175, 55, 0.5);
+}
+
+.btn--secondary {
+  background: var(--color-accent);
+  color: #000;
+  box-shadow: 0 0 0.5rem rgba(212, 175, 55, 0.4);
+}
+
+.btn--secondary:hover {
+  box-shadow: 0 0 1rem rgba(212, 175, 55, 0.6);
+}
+
+.card {
+  background: var(--color-glass);
+  border: 1px solid var(--color-glass-border);
+  border-radius: var(--radius);
+  backdrop-filter: blur(10px);
+  padding: 1rem;
+  transition: transform 0.4s ease, box-shadow 0.4s ease;
+}
+
+.spotlight-card img {
+  width: 100%;
+  border-radius: var(--radius);
+  margin-bottom: 1rem;
+}
+
+.card__body h3 {
+  margin-bottom: 0.5rem;
+}
+
+.preview-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.preview-list li + li {
+  margin-top: 0.25rem;
+}
+
+.nav__brand {
+  font-weight: 600;
+}
+
+.nav__links a {
+  font-size: 0.9rem;
+  transition: color 0.3s ease;
+}
+
+.nav__links a:hover {
+  color: var(--color-accent);
+}
+
+.nav__links a.active {
+  color: var(--color-accent);
+}
+
+.nav__actions {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.nav__auth {
+  font-size: 0.9rem;
+  transition: color 0.3s ease;
+}
+
+.nav__auth:hover {
+  color: var(--color-accent);
+}
+
+.talent__search {
+  display: block;
+  width: 100%;
+  max-width: 400px;
+  margin: 0 auto var(--gutter);
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius);
+  border: 1px solid var(--color-glass-border);
+  background: var(--color-glass);
+  color: var(--color-text);
+}
+
+.rating {
+  color: var(--color-accent);
+  margin: 0.5rem 0;
+}
+
+.skills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.tag {
+  background: rgba(212, 175, 55, 0.1);
+  color: var(--color-accent);
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius);
+  font-size: 0.75rem;
+  border: 1px solid rgba(212, 175, 55, 0.3);
+}
+
+.talent__filter {
+  background: var(--color-glass);
+  border: 1px solid var(--color-glass-border);
+  color: var(--color-text);
+  border-radius: var(--radius);
+  padding: 0.35rem 0.75rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.talent__filter.is-active {
+  background: var(--color-accent);
+  color: #000;
+}
+
+.talent-card .btn--hire {
+  margin-top: 0.75rem;
+  width: 100%;
+}
+
+.card:hover,
+.card:focus {
+  transform: scale(1.03);
+  box-shadow: 0 0 1rem rgba(212, 175, 55, 0.25);
+}
+
+.feature {
+  background: var(--color-glass);
+  border-radius: var(--radius);
+  padding: 2rem 1rem;
+  border: 1px solid var(--color-glass-border);
+}
+
+.feature:hover,
+.feature:focus {
+  box-shadow: 0 0 1rem rgba(212, 175, 55, 0.25);
+}
+
+.carousel__indicator {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--color-glass-border);
+  margin: 0 4px;
+  cursor: pointer;
+  transition: background 0.3s ease;
+}
+
+.carousel__indicator.is-active {
+  background: var(--color-accent);
+}
+
+/* Talent enhancements */
+.talent-card {
+  position: relative;
+}
+
+.talent-card__name {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-weight: 600;
+}
+
+.badge--verified {
+  display: inline-flex;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  background: var(--color-accent);
+  color: #000;
+  font-size: 0.65rem;
+  align-items: center;
+  justify-content: center;
+}
+
+.talent-card__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.availability {
+  font-size: 0.8rem;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.availability::before {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.availability--open::before {
+  background: #4caf50;
+}
+
+.availability--busy::before {
+  background: #b71c1c;
+}
+
+.talent__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+  margin-bottom: var(--gutter);
+}
+
+.talent__sort {
+  border: 1px solid var(--color-glass-border);
+  border-radius: var(--radius);
+  background: var(--color-glass);
+  color: var(--color-text);
+  padding: 0.5rem 1rem;
+}
+
+/* Spotlight marquee */
+.spotlight__marquee {
+  overflow: hidden;
+  position: relative;
+}
+
+.spotlight__inner {
+  display: flex;
+  gap: var(--gutter);
+  width: max-content;
+  animation: spotlight-scroll 30s linear infinite;
+}
+
+.spotlight__inner:hover {
+  animation-play-state: paused;
+}
+
+.spotlight__col {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gutter);
+}
+
+.spotlight__col video {
+  width: 200px;
+  height: 120px;
+  object-fit: cover;
+  border-radius: var(--radius);
+  background: var(--color-glass);
+  border: 1px solid var(--color-glass-border);
+}
+
+@keyframes spotlight-scroll {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+@media (max-width: 600px) {
+  .spotlight__col video {
+    width: 45vw;
+    height: auto;
+  }
+}
+
+/* Banner videos */
+.banner__grid video {
+  width: 100%;
+  border-radius: var(--radius);
+  background: var(--color-glass);
+  border: 1px solid var(--color-glass-border);
+}
+
+/* Creative hub marquee */
+.hub__marquee {
+  overflow: hidden;
+  position: relative;
+}
+
+.hub__inner {
+  display: flex;
+  gap: var(--gutter);
+  width: max-content;
+  animation: hub-scroll 40s linear infinite;
+}
+
+.hub__inner:hover {
+  animation-play-state: paused;
+}
+
+.hub__inner img {
+  width: 300px;
+  height: 180px;
+  object-fit: cover;
+  border-radius: var(--radius);
+  background: var(--color-glass);
+  border: 1px solid var(--color-glass-border);
+}
+
+@keyframes hub-scroll {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+@media (max-width: 600px) {
+  .hub__inner img {
+    width: 45vw;
+    height: auto;
+  }
+}
+
+/* Categories */
+.category-btn {
+  background: var(--color-glass);
+  border: 1px solid var(--color-glass-border);
+  color: var(--color-text);
+  border-radius: var(--radius);
+  padding: 0.35rem 0.75rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.category-btn.is-active {
+  background: var(--color-accent);
+  color: #000;
+}
+
+/* Recommended items */
+.recommended__item {
+  background: var(--color-glass);
+  border: 1px solid var(--color-glass-border);
+  border-radius: var(--radius);
+  padding: 1rem;
+  backdrop-filter: blur(10px);
+}
+
+.recommended__item video {
+  width: 100%;
+  border-radius: var(--radius);
+  display: block;
+}

--- a/css/layout.css
+++ b/css/layout.css
@@ -1,0 +1,213 @@
+.hero {
+  position: relative;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  padding: var(--gutter);
+  overflow: hidden;
+}
+
+.nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem var(--gutter);
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(10px);
+  z-index: 10;
+}
+
+.progress {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 3px;
+  background: linear-gradient(
+    to right,
+    var(--color-accent),
+    var(--color-accent-dark)
+  );
+  width: 0%;
+  transition: width 0.15s ease-out;
+  z-index: 20;
+  pointer-events: none;
+}
+
+.nav__links {
+  display: flex;
+  gap: 1rem;
+}
+
+.hero__inner {
+  max-width: var(--max-width);
+  z-index: 1;
+}
+
+.hero__cta {
+  margin-top: 2rem;
+}
+
+.hero__video {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.hero__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  pointer-events: none;
+}
+
+.spotlight {
+  padding: var(--gutter);
+  max-width: var(--max-width);
+  margin: 0 auto;
+}
+
+.banner {
+  padding: var(--gutter);
+  max-width: var(--max-width);
+  margin: 0 auto;
+}
+
+.banner__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: var(--gutter);
+}
+
+.talent {
+  padding: var(--gutter);
+  max-width: var(--max-width);
+  margin: 0 auto;
+}
+
+.hub {
+  padding: var(--gutter);
+  max-width: var(--max-width);
+  margin: 0 auto;
+}
+
+.categories {
+  padding: var(--gutter);
+  max-width: var(--max-width);
+  margin: 0 auto;
+  text-align: center;
+}
+
+.categories__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: center;
+}
+
+.recommended {
+  padding: var(--gutter);
+  max-width: var(--max-width);
+  margin: 0 auto;
+}
+
+.recommended__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: var(--gutter);
+}
+
+.talent__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: center;
+  margin-bottom: var(--gutter);
+}
+
+.talent__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: var(--gutter);
+}
+
+.showcase {
+  padding: var(--gutter);
+  max-width: var(--max-width);
+  margin: 0 auto;
+}
+
+.carousel {
+  position: relative;
+  overflow: hidden;
+}
+
+.carousel__track {
+  display: flex;
+  transition: transform 0.6s ease;
+}
+
+.carousel__slide {
+  min-width: 100%;
+}
+
+.carousel__control {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 2rem;
+  padding: 0 0.5rem;
+  color: var(--color-text);
+  background: rgba(0,0,0,0.4);
+}
+
+.carousel__control.prev { left: 0; }
+.carousel__control.next { right: 0; }
+
+.carousel__indicators {
+  position: absolute;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.why {
+  padding: var(--gutter);
+  max-width: var(--max-width);
+  margin: 0 auto;
+}
+
+.why__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: var(--gutter);
+  text-align: center;
+}
+
+.final-cta {
+  text-align: center;
+  padding: 6rem var(--gutter);
+  background: radial-gradient(circle at top, rgba(212, 175, 55, 0.15), transparent 70%),
+              radial-gradient(circle at bottom, rgba(212, 175, 55, 0.15), transparent 70%);
+}
+
+@media (max-width: 600px) {
+  .nav {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .nav__actions {
+    justify-content: center;
+  }
+}

--- a/css/motion.css
+++ b/css/motion.css
@@ -1,0 +1,49 @@
+@media (prefers-reduced-motion: no-preference) {
+  [data-reveal] {
+    opacity: 0;
+    transform: translateY(20px);
+    transition: opacity 0.6s ease, transform 0.6s ease;
+  }
+
+  [data-reveal].is-visible {
+    opacity: 1;
+    transform: none;
+  }
+
+  .hero__overlay {
+    animation: aura 20s linear infinite;
+  }
+
+  .tilt {
+    transition: transform 0.2s ease-out;
+  }
+}
+
+@keyframes aura {
+  from {
+    filter: hue-rotate(0deg);
+  }
+  to {
+    filter: hue-rotate(360deg);
+  }
+}
+
+.cursor {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  mix-blend-mode: difference;
+  pointer-events: none;
+  transform: translate(-50%, -50%);
+  transition: transform 0.15s ease-out, width 0.15s ease-out, height 0.15s ease-out;
+  z-index: var(--z-cursor);
+}
+
+.cursor.is-hovering {
+  width: 40px;
+  height: 40px;
+}

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -1,0 +1,20 @@
+:root {
+  /* Colors */
+  --color-bg: #0a0a0a;
+  --color-text: #eaeaea;
+  --color-accent: #d4af37;
+  --color-accent-dark: #8c7830;
+  --color-glass: rgba(255, 255, 255, 0.06);
+  --color-glass-border: rgba(255, 255, 255, 0.1);
+
+  /* Typography */
+  --font-family-sans: 'Inter', system-ui, sans-serif;
+
+  /* Sizing */
+  --max-width: 1200px;
+  --radius: 12px;
+  --gutter: clamp(1rem, 2vw, 2rem);
+
+  /* Z-index */
+  --z-cursor: 1000;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,288 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PPS – The Creative Post-Production Theatre</title>
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@200;400;600;800&display=swap" as="style" />
+    <link rel="stylesheet" href="css/tokens.css" />
+    <link rel="stylesheet" href="css/base.css" />
+    <link rel="stylesheet" href="css/layout.css" />
+    <link rel="stylesheet" href="css/components.css" />
+    <link rel="stylesheet" href="css/motion.css" />
+    <script type="module" src="js/reveal.js" defer></script>
+    <script type="module" src="js/parallax.js" defer></script>
+    <script type="module" src="js/cursor.js" defer></script>
+    <script type="module" src="js/magnetic.js" defer></script>
+    <script type="module" src="js/router.js" defer></script>
+    <script type="module" src="js/search.js" defer></script>
+    <script type="module" src="js/tilt.js" defer></script>
+    <script type="module" src="js/progress.js" defer></script>
+    <script type="module" src="js/hire.js" defer></script>
+    <script type="module" src="js/recommend.js" defer></script>
+    <script type="module" src="js/spotlight.js" defer></script>
+  </head>
+  <body class="theme-dark">
+    <div class="cursor" aria-hidden="true"></div>
+    <div class="progress" aria-hidden="true"></div>
+    <nav class="nav" aria-label="main navigation">
+      <div class="nav__brand">PPS</div>
+      <div class="nav__links">
+        <a href="#community">Community</a>
+        <a href="#talent">Talent</a>
+        <a href="#showcase">Reel</a>
+        <a href="#why">Why</a>
+      </div>
+      <div class="nav__actions">
+        <a href="#login" class="nav__auth">Login</a>
+        <button class="btn btn--primary btn--small magnetic" data-link="#join">Sign Up</button>
+      </div>
+    </nav>
+    <header class="hero" id="hero">
+      <video
+        class="hero__video"
+        src="https://www.w3schools.com/howto/rain.mp4"
+        autoplay
+        loop
+        muted
+        playsinline
+        aria-hidden="true"
+      ></video>
+      <div class="hero__overlay" aria-hidden="true"></div>
+      <div class="hero__inner" data-reveal>
+        <h1 class="hero__title" data-parallax>PPS – The Creative Post-Production Theatre.</h1>
+        <p class="hero__subtitle">Where editors, VFX artists, and cinematographers connect, share, and showcase their craft.</p>
+        <button class="btn btn--primary btn--glass btn--pill hero__cta magnetic" data-link="#community">Enter the Theatre</button>
+      </div>
+    </header>
+
+    <main>
+      <section class="banner" id="banner">
+        <h2 class="section-title">Now Playing</h2>
+        <div class="banner__grid">
+          <video src="https://www.w3schools.com/html/mov_bbb.mp4" muted loop playsinline></video>
+          <video src="https://www.w3schools.com/html/movie.mp4" muted loop playsinline></video>
+          <video src="https://www.w3schools.com/html/mov_bbb.mp4" muted loop playsinline></video>
+        </div>
+      </section>
+
+      <section class="spotlight" id="community">
+        <h2 class="section-title">Community Spotlight</h2>
+        <div class="spotlight__marquee">
+          <div class="spotlight__inner">
+            <div class="spotlight__col">
+              <video src="https://www.w3schools.com/html/mov_bbb.mp4" muted loop playsinline></video>
+              <video src="https://www.w3schools.com/html/movie.mp4" muted loop playsinline></video>
+            </div>
+            <div class="spotlight__col">
+              <video src="https://www.w3schools.com/html/movie.mp4" muted loop playsinline></video>
+              <video src="https://www.w3schools.com/html/mov_bbb.mp4" muted loop playsinline></video>
+            </div>
+            <div class="spotlight__col">
+              <video src="https://www.w3schools.com/html/mov_bbb.mp4" muted loop playsinline></video>
+              <video src="https://www.w3schools.com/html/movie.mp4" muted loop playsinline></video>
+            </div>
+            <!-- duplicate columns for seamless scroll -->
+            <div class="spotlight__col">
+              <video src="https://www.w3schools.com/html/mov_bbb.mp4" muted loop playsinline></video>
+              <video src="https://www.w3schools.com/html/movie.mp4" muted loop playsinline></video>
+            </div>
+            <div class="spotlight__col">
+              <video src="https://www.w3schools.com/html/movie.mp4" muted loop playsinline></video>
+              <video src="https://www.w3schools.com/html/mov_bbb.mp4" muted loop playsinline></video>
+            </div>
+            <div class="spotlight__col">
+              <video src="https://www.w3schools.com/html/mov_bbb.mp4" muted loop playsinline></video>
+              <video src="https://www.w3schools.com/html/movie.mp4" muted loop playsinline></video>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="talent" id="talent">
+        <h2 class="section-title">Top Talent</h2>
+        <div class="talent__controls">
+          <input
+            type="search"
+            id="talent-search"
+            class="talent__search"
+            placeholder="Search by name or skill"
+            aria-label="search talent"
+          />
+          <select id="talent-sort" class="talent__sort" aria-label="sort talent">
+            <option value="rating">Rating</option>
+            <option value="name">Name</option>
+          </select>
+        </div>
+        <div class="talent__filters"></div>
+        <div class="talent__grid">
+          <article
+            class="card talent-card tilt"
+            data-name="Ava Cortez"
+            data-skills="editing color"
+            data-rating="5"
+            data-available="true"
+            data-reveal
+          >
+            <img
+              src="https://via.placeholder.com/400x250?text=Ava"
+              alt="Portrait of Ava Cortez"
+              loading="lazy"
+            />
+            <h3 class="talent-card__name">Ava Cortez <span class="badge--verified" title="Verified">✔</span></h3>
+            <div class="talent-card__meta">
+              <p class="rating" aria-label="rating 5 out of 5">★★★★★</p>
+              <span class="availability availability--open">Available</span>
+            </div>
+            <p class="skills">
+              <span class="tag">Editing</span><span class="tag">Color</span>
+            </p>
+            <button class="btn btn--secondary btn--small btn--hire magnetic">Hire</button>
+          </article>
+          <article
+            class="card talent-card tilt"
+            data-name="Liam Chen"
+            data-skills="vfx compositing"
+            data-rating="4"
+            data-available="false"
+            data-reveal
+          >
+            <img
+              src="https://via.placeholder.com/400x250?text=Liam"
+              alt="Portrait of Liam Chen"
+              loading="lazy"
+            />
+            <h3 class="talent-card__name">Liam Chen <span class="badge--verified" title="Verified">✔</span></h3>
+            <div class="talent-card__meta">
+              <p class="rating" aria-label="rating 4 out of 5">★★★★☆</p>
+              <span class="availability availability--busy">Busy</span>
+            </div>
+            <p class="skills">
+              <span class="tag">VFX</span><span class="tag">Compositing</span>
+            </p>
+            <button class="btn btn--secondary btn--small btn--hire magnetic">Hire</button>
+          </article>
+          <article
+            class="card talent-card tilt"
+            data-name="Sophia Patel"
+            data-skills="cinematography lighting"
+            data-rating="5"
+            data-available="true"
+            data-reveal
+          >
+            <img
+              src="https://via.placeholder.com/400x250?text=Sophia"
+              alt="Portrait of Sophia Patel"
+              loading="lazy"
+            />
+            <h3 class="talent-card__name">Sophia Patel <span class="badge--verified" title="Verified">✔</span></h3>
+            <div class="talent-card__meta">
+              <p class="rating" aria-label="rating 5 out of 5">★★★★★</p>
+              <span class="availability availability--open">Available</span>
+            </div>
+            <p class="skills">
+              <span class="tag">Cinematography</span><span class="tag">Lighting</span>
+            </p>
+            <button class="btn btn--secondary btn--small btn--hire magnetic">Hire</button>
+          </article>
+        </div>
+      </section>
+      <section class="hub" id="hub">
+        <h2 class="section-title">Creative Hub</h2>
+        <div class="hub__marquee">
+          <div class="hub__inner">
+            <img src="https://via.placeholder.com/300x180?text=Work+1" alt="Work 1" loading="lazy" />
+            <img src="https://via.placeholder.com/300x180?text=Work+2" alt="Work 2" loading="lazy" />
+            <img src="https://via.placeholder.com/300x180?text=Work+3" alt="Work 3" loading="lazy" />
+            <img src="https://via.placeholder.com/300x180?text=Work+4" alt="Work 4" loading="lazy" />
+            <img src="https://via.placeholder.com/300x180?text=Work+5" alt="Work 5" loading="lazy" />
+            <img src="https://via.placeholder.com/300x180?text=Work+6" alt="Work 6" loading="lazy" />
+            <img src="https://via.placeholder.com/300x180?text=Work+1" alt="Work 1" loading="lazy" />
+            <img src="https://via.placeholder.com/300x180?text=Work+2" alt="Work 2" loading="lazy" />
+            <img src="https://via.placeholder.com/300x180?text=Work+3" alt="Work 3" loading="lazy" />
+            <img src="https://via.placeholder.com/300x180?text=Work+4" alt="Work 4" loading="lazy" />
+            <img src="https://via.placeholder.com/300x180?text=Work+5" alt="Work 5" loading="lazy" />
+            <img src="https://via.placeholder.com/300x180?text=Work+6" alt="Work 6" loading="lazy" />
+          </div>
+        </div>
+      </section>
+
+      <section class="categories" id="categories">
+        <h2 class="section-title">Browse by Category</h2>
+        <div class="categories__list">
+          <button class="category-btn is-active" data-category="all">All</button>
+          <button class="category-btn" data-category="effects">Video Effects</button>
+          <button class="category-btn" data-category="music">Music Video</button>
+          <button class="category-btn" data-category="cinema">Cinematography</button>
+        </div>
+      </section>
+
+      <section class="recommended" id="recommended">
+        <h2 class="section-title">Recommended for You</h2>
+        <div class="recommended__grid">
+          <article class="recommended__item tilt" data-category="effects" data-reveal>
+            <video src="https://www.w3schools.com/html/mov_bbb.mp4" muted loop playsinline></video>
+          </article>
+          <article class="recommended__item tilt" data-category="music" data-reveal>
+            <video src="https://www.w3schools.com/html/movie.mp4" muted loop playsinline></video>
+          </article>
+          <article class="recommended__item tilt" data-category="cinema" data-reveal>
+            <video src="https://www.w3schools.com/html/mov_bbb.mp4" muted loop playsinline></video>
+          </article>
+          <article class="recommended__item tilt" data-category="effects" data-reveal>
+            <video src="https://www.w3schools.com/html/movie.mp4" muted loop playsinline></video>
+          </article>
+          <article class="recommended__item tilt" data-category="music" data-reveal>
+            <video src="https://www.w3schools.com/html/mov_bbb.mp4" muted loop playsinline></video>
+          </article>
+          <article class="recommended__item tilt" data-category="cinema" data-reveal>
+            <video src="https://www.w3schools.com/html/movie.mp4" muted loop playsinline></video>
+          </article>
+        </div>
+      </section>
+
+      <section class="showcase" id="showcase">
+        <h2 class="section-title">Showcase Reel</h2>
+        <div class="carousel" aria-label="showcase reel">
+          <button class="carousel__control prev" aria-label="previous clip">&#10094;</button>
+          <div class="carousel__track">
+            <video class="carousel__slide" src="https://www.w3schools.com/html/mov_bbb.mp4" muted loop></video>
+            <video class="carousel__slide" src="https://www.w3schools.com/html/movie.mp4" muted loop></video>
+            <video class="carousel__slide" src="https://www.w3schools.com/html/mov_bbb.mp4" muted loop></video>
+          </div>
+          <button class="carousel__control next" aria-label="next clip">&#10095;</button>
+          <ul class="carousel__indicators" aria-label="carousel indicators"></ul>
+        </div>
+      </section>
+
+      <section class="why" id="why">
+        <h2 class="section-title">Why PPS?</h2>
+        <div class="why__grid">
+          <article class="feature tilt" data-reveal>
+            <h3>Collaborate</h3>
+            <p>Ask for feedback and learn from the community.</p>
+          </article>
+          <article class="feature tilt" data-reveal>
+            <h3>Showcase</h3>
+            <p>Publish your work to an audience of peers.</p>
+          </article>
+          <article class="feature tilt" data-reveal>
+            <h3>Get Hired</h3>
+            <p>Find paid opportunities and gigs.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="final-cta" id="join" data-reveal>
+        <h2>Your Theatre Awaits.</h2>
+        <button class="btn btn--secondary magnetic">Join PPS Now</button>
+      </section>
+    </main>
+
+    <script>
+      if (navigator.userAgent.includes('AppleWebKit')) {
+        document.body.classList.add('webkit');
+      }
+    </script>
+  </body>
+</html>

--- a/js/cursor.js
+++ b/js/cursor.js
@@ -1,0 +1,15 @@
+const cursor = document.querySelector('.cursor');
+
+function moveCursor(e) {
+  cursor.style.left = `${e.clientX}px`;
+  cursor.style.top = `${e.clientY}px`;
+}
+
+document.addEventListener('mousemove', moveCursor);
+
+// hover enlarge
+const interactive = document.querySelectorAll('a, button, .magnetic');
+interactive.forEach((el) => {
+  el.addEventListener('mouseenter', () => cursor.classList.add('is-hovering'));
+  el.addEventListener('mouseleave', () => cursor.classList.remove('is-hovering'));
+});

--- a/js/hire.js
+++ b/js/hire.js
@@ -1,0 +1,9 @@
+const buttons = document.querySelectorAll('.btn--hire');
+
+buttons.forEach((btn) => {
+  btn.addEventListener('click', () => {
+    const card = btn.closest('.talent-card');
+    const name = card?.dataset.name || 'talent';
+    window.location.href = `mailto:hire@pps.dev?subject=Hire%20${encodeURIComponent(name)}`;
+  });
+});

--- a/js/magnetic.js
+++ b/js/magnetic.js
@@ -1,0 +1,14 @@
+const magneticItems = document.querySelectorAll('.magnetic');
+
+magneticItems.forEach((item) => {
+  const strength = 30;
+  item.addEventListener('mousemove', (e) => {
+    const rect = item.getBoundingClientRect();
+    const x = e.clientX - rect.left - rect.width / 2;
+    const y = e.clientY - rect.top - rect.height / 2;
+    item.style.transform = `translate(${x / strength}px, ${y / strength}px)`;
+  });
+  item.addEventListener('mouseleave', () => {
+    item.style.transform = 'translate(0, 0)';
+  });
+});

--- a/js/parallax.js
+++ b/js/parallax.js
@@ -1,0 +1,14 @@
+const parallaxEls = document.querySelectorAll('[data-parallax]');
+
+function onScroll() {
+  const scrollY = window.scrollY;
+  parallaxEls.forEach((el) => {
+    el.style.transform = `translateY(${scrollY * -0.2}px)`;
+  });
+}
+
+export function initParallax() {
+  window.addEventListener('scroll', onScroll, { passive: true });
+}
+
+initParallax();

--- a/js/progress.js
+++ b/js/progress.js
@@ -1,0 +1,8 @@
+const bar = document.querySelector('.progress');
+function update() {
+  const h = document.documentElement.scrollHeight - window.innerHeight;
+  const scrolled = (window.scrollY / h) * 100;
+  bar.style.width = `${scrolled}%`;
+}
+window.addEventListener('scroll', update);
+update();

--- a/js/recommend.js
+++ b/js/recommend.js
@@ -1,0 +1,14 @@
+const buttons = document.querySelectorAll('.category-btn');
+const items = document.querySelectorAll('.recommended__item');
+
+buttons.forEach((btn) => {
+  btn.addEventListener('click', () => {
+    buttons.forEach((b) => b.classList.remove('is-active'));
+    btn.classList.add('is-active');
+    const cat = btn.dataset.category;
+    items.forEach((item) => {
+      const show = cat === 'all' || item.dataset.category === cat;
+      item.style.display = show ? '' : 'none';
+    });
+  });
+});

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -1,0 +1,14 @@
+const observer = new IntersectionObserver((entries) => {
+  entries.forEach((entry) => {
+    if (entry.isIntersecting) {
+      entry.target.classList.add('is-visible');
+      observer.unobserve(entry.target);
+    }
+  });
+}, { threshold: 0.1 });
+
+export function reveal() {
+  document.querySelectorAll('[data-reveal]').forEach((el) => observer.observe(el));
+}
+
+reveal();

--- a/js/router.js
+++ b/js/router.js
@@ -1,0 +1,103 @@
+function navigate(hash) {
+  const target = document.querySelector(hash);
+  if (target) {
+    target.scrollIntoView({ behavior: 'smooth' });
+  }
+}
+
+document.querySelectorAll('[data-link]').forEach((btn) => {
+  btn.addEventListener('click', (e) => {
+    const hash = btn.getAttribute('data-link');
+    if (document.startViewTransition) {
+      document.startViewTransition(() => navigate(hash));
+    } else {
+      navigate(hash);
+    }
+  });
+});
+
+// nav scroll spy
+const navLinks = document.querySelectorAll('.nav__links a');
+const sections = document.querySelectorAll('main section');
+const linkMap = new Map();
+navLinks.forEach((link) => linkMap.set(link.getAttribute('href').slice(1), link));
+
+const spy = new IntersectionObserver(
+  (entries) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        navLinks.forEach((l) => l.classList.remove('active'));
+        const active = linkMap.get(entry.target.id);
+        if (active) active.classList.add('active');
+      }
+    });
+  },
+  { rootMargin: '-50% 0px -50% 0px', threshold: 0 }
+);
+
+sections.forEach((section) => spy.observe(section));
+
+// Enhanced video carousel
+const track = document.querySelector('.carousel__track');
+const slides = Array.from(track.children);
+const indicatorsWrap = document.querySelector('.carousel__indicators');
+let index = 0;
+
+slides.forEach((_, i) => {
+  const li = document.createElement('li');
+  const btn = document.createElement('button');
+  btn.className = 'carousel__indicator';
+  btn.setAttribute('aria-label', `Go to slide ${i + 1}`);
+  btn.addEventListener('click', () => {
+    index = i;
+    showSlide(index);
+  });
+  li.appendChild(btn);
+  indicatorsWrap.appendChild(li);
+});
+
+const indicators = Array.from(
+  indicatorsWrap.querySelectorAll('.carousel__indicator')
+);
+
+function showSlide(i) {
+  track.style.transform = `translateX(-${i * 100}%)`;
+  slides.forEach((v, idx) => {
+    if (idx === i) {
+      v.play();
+    } else {
+      v.pause();
+      v.currentTime = 0;
+    }
+  });
+  indicators.forEach((dot, idx) =>
+    dot.classList.toggle('is-active', idx === i)
+  );
+}
+
+document.querySelector('.carousel__control.next').addEventListener('click', () => {
+  index = (index + 1) % slides.length;
+  showSlide(index);
+});
+
+document.querySelector('.carousel__control.prev').addEventListener('click', () => {
+  index = (index - 1 + slides.length) % slides.length;
+  showSlide(index);
+});
+
+let timer = setInterval(() => {
+  index = (index + 1) % slides.length;
+  showSlide(index);
+}, 8000);
+
+const carousel = document.querySelector('.carousel');
+carousel.addEventListener('mouseenter', () => clearInterval(timer));
+carousel.addEventListener('mouseleave', () => {
+  timer = setInterval(() => {
+    index = (index + 1) % slides.length;
+    showSlide(index);
+  }, 8000);
+});
+
+slides.forEach((v) => v.setAttribute('playsinline', ''));
+showSlide(index);

--- a/js/search.js
+++ b/js/search.js
@@ -1,0 +1,71 @@
+const input = document.getElementById('talent-search');
+const filtersContainer = document.querySelector('.talent__filters');
+const sortSelect = document.getElementById('talent-sort');
+const grid = document.querySelector('.talent__grid');
+
+export function initTalentSearch() {
+  if (!input || !filtersContainer || !grid) return;
+  const cards = Array.from(document.querySelectorAll('.talent-card'));
+  const skills = new Set();
+  cards.forEach((card) =>
+    card.dataset.skills.split(' ').forEach((skill) => skills.add(skill))
+  );
+
+  skills.forEach((skill) => {
+    const btn = document.createElement('button');
+    btn.className = 'talent__filter';
+    btn.textContent = skill.charAt(0).toUpperCase() + skill.slice(1);
+    btn.dataset.skill = skill;
+    btn.addEventListener('click', () => {
+      btn.classList.toggle('is-active');
+      filter();
+    });
+    filtersContainer.appendChild(btn);
+  });
+
+  const availBtn = document.createElement('button');
+  availBtn.className = 'talent__filter';
+  availBtn.textContent = 'Available Now';
+  availBtn.dataset.available = 'true';
+  availBtn.addEventListener('click', () => {
+    availBtn.classList.toggle('is-active');
+    filter();
+  });
+  filtersContainer.appendChild(availBtn);
+
+  function filter() {
+    const query = input.value.toLowerCase();
+    const activeSkills = Array.from(
+      filtersContainer.querySelectorAll('.talent__filter.is-active[data-skill]')
+    ).map((b) => b.dataset.skill);
+    const requireAvailable = availBtn.classList.contains('is-active');
+
+    cards.forEach((card) => {
+      const text = `${card.dataset.name} ${card.dataset.skills}`.toLowerCase();
+      const matchesQuery = text.includes(query);
+      const matchesSkills =
+        activeSkills.length === 0 ||
+        activeSkills.every((skill) => card.dataset.skills.includes(skill));
+      const matchesAvail = !requireAvailable || card.dataset.available === 'true';
+      card.style.display = matchesQuery && matchesSkills && matchesAvail ? '' : 'none';
+    });
+
+    sort();
+  }
+
+  function sort() {
+    const visible = cards.filter((c) => c.style.display !== 'none');
+    visible.sort((a, b) => {
+      if (sortSelect.value === 'name') {
+        return a.dataset.name.localeCompare(b.dataset.name);
+      }
+      return Number(b.dataset.rating) - Number(a.dataset.rating);
+    });
+    visible.forEach((card) => grid.appendChild(card));
+  }
+
+  input.addEventListener('input', filter);
+  sortSelect.addEventListener('change', filter);
+}
+
+initTalentSearch();

--- a/js/spotlight.js
+++ b/js/spotlight.js
@@ -1,0 +1,17 @@
+const videos = document.querySelectorAll('.spotlight video, .banner video, .recommended video');
+
+const observer = new IntersectionObserver((entries) => {
+  entries.forEach((entry) => {
+    if (entry.isIntersecting) {
+      entry.target.play();
+    } else {
+      entry.target.pause();
+    }
+  });
+}, { threshold: 0.5 });
+
+videos.forEach((video) => {
+  observer.observe(video);
+  video.addEventListener('mouseenter', () => video.pause());
+  video.addEventListener('mouseleave', () => video.play());
+});

--- a/js/tilt.js
+++ b/js/tilt.js
@@ -1,0 +1,14 @@
+const items = document.querySelectorAll('.tilt');
+const max = 10;
+
+items.forEach((el) => {
+  el.addEventListener('mousemove', (e) => {
+    const rect = el.getBoundingClientRect();
+    const x = (e.clientX - rect.left) / rect.width - 0.5;
+    const y = (e.clientY - rect.top) / rect.height - 0.5;
+    el.style.transform = `perspective(600px) rotateX(${ -y * max }deg) rotateY(${ x * max }deg) scale(1.03)`;
+  });
+  el.addEventListener('mouseleave', () => {
+    el.style.transform = '';
+  });
+});


### PR DESCRIPTION
## Summary
- add promotional banner with autoplaying video tiles
- replace gallery with Creative Hub marquee and add category-filtered recommendations
- include JS filtering logic for personalized video suggestions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a193f09a3c832abef5097e24062843