### PR TITLE
feat: add animated responsive homepage for Fab Distro

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "fab-distro",
+  "version": "1.0.0",
+  "description": "Fab Distro modern homepage",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo 'No tests specified' && exit 0"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "framer-motion": "^10.16.4"
+  },
+  "devDependencies": {
+    "vite": "^4.3.9",
+    "@vitejs/plugin-react": "^4.0.0",
+    "tailwindcss": "^3.4.4",
+    "postcss": "^8.4.27",
+    "autoprefixer": "^10.4.14"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fab Distro</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import Navbar from './components/Navbar';
+import Hero from './components/Hero';
+import Features from './components/Features';
+import ArtistSlider from './components/ArtistSlider';
+import CTASection from './components/CTASection';
+import Footer from './components/Footer';
+
+const App = () => {
+  return (
+    <>
+      <Navbar />
+      <main>
+        <Hero />
+        <Features />
+        <ArtistSlider />
+        <CTASection />
+      </main>
+      <Footer />
+    </>
+  );
+};
+
+export default App;

--- a/src/components/ArtistSlider.jsx
+++ b/src/components/ArtistSlider.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+const artists = [
+  {
+    name: 'Nova Beats',
+    img: 'https://images.unsplash.com/photo-1524678606370-a47ad25cb82a',
+    quote: 'Fab Distro took my music global overnight.',
+  },
+  {
+    name: 'Echo Lane',
+    img: 'https://images.unsplash.com/photo-1485579149621-3123dd979885',
+    quote: 'The analytics dashboard keeps me in control of my career.',
+  },
+  {
+    name: 'Rhythmix',
+    img: 'https://images.unsplash.com/photo-1497032205916-ac775f0649ae',
+    quote: 'Transparent royalties mean I never miss a payment.',
+  },
+];
+
+const ArtistSlider = () => {
+  return (
+    <section id="artists" className="py-24">
+      <div className="container">
+        <h2 className="text-3xl md:text-5xl font-bold text-center mb-12">Artist Success Stories</h2>
+        <motion.div
+          className="flex gap-6 overflow-x-auto pb-4"
+          whileTap={{ cursor: 'grabbing' }}
+        >
+          {artists.map((artist) => (
+            <motion.article
+              key={artist.name}
+              className="min-w-[280px] bg-gray-800 rounded-lg p-6 flex-shrink-0"
+              whileHover={{ scale: 1.03 }}
+            >
+              <img
+                src={artist.img}
+                alt={artist.name}
+                className="h-40 w-full object-cover rounded-md mb-4"
+              />
+              <h3 className="text-xl font-semibold mb-2">{artist.name}</h3>
+              <p className="text-gray-300 text-sm">“{artist.quote}”</p>
+            </motion.article>
+          ))}
+        </motion.div>
+      </div>
+    </section>
+  );
+};
+
+export default ArtistSlider;

--- a/src/components/CTASection.jsx
+++ b/src/components/CTASection.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+const CTASection = () => {
+  return (
+    <section id="cta" className="py-24 bg-gradient-to-r from-orange-500 to-pink-500 text-black">
+      <div className="container text-center">
+        <motion.h2
+          className="text-3xl md:text-5xl font-bold mb-6"
+          initial={{ opacity: 0, scale: 0.9 }}
+          whileInView={{ opacity: 1, scale: 1 }}
+          viewport={{ once: true, amount: 0.6 }}
+        >
+          Ready to Amplify Your Music?
+        </motion.h2>
+        <p className="text-lg mb-10 max-w-2xl mx-auto">
+          Join Fab Distro today and start distributing your music to every corner of the globe.
+        </p>
+        <a
+          href="#"
+          className="bg-black text-white font-semibold px-8 py-4 rounded-md inline-block"
+        >
+          Sign Up Free
+        </a>
+      </div>
+    </section>
+  );
+};
+
+export default CTASection;

--- a/src/components/Features.jsx
+++ b/src/components/Features.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+const features = [
+  {
+    title: 'Global Reach',
+    text: 'Distribute your tracks to 200+ platforms worldwide with a single upload.',
+    icon: '🌍',
+  },
+  {
+    title: 'Real-Time Analytics',
+    text: 'Track streams, downloads, and earnings with up-to-the-minute dashboards.',
+    icon: '📈',
+  },
+  {
+    title: 'Royalty Transparency',
+    text: 'Know exactly when and how you get paid with clear royalty tracking.',
+    icon: '💰',
+  },
+];
+
+const Features = () => {
+  return (
+    <section className="bg-black" id="features">
+      <div className="container py-24">
+        <h2 className="text-3xl md:text-5xl font-bold text-center mb-16">Why Fab Distro?</h2>
+        <div className="grid md:grid-cols-3 gap-12">
+          {features.map((feature, idx) => (
+            <motion.div
+              key={feature.title}
+              initial={{ opacity: 0, y: 30 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, amount: 0.5 }}
+              transition={{ delay: idx * 0.2 }}
+              className="text-center"
+            >
+              <div className="text-5xl mb-4" aria-hidden="true">{feature.icon}</div>
+              <h3 className="text-xl font-semibold mb-2">{feature.title}</h3>
+              <p className="text-gray-300 leading-relaxed">{feature.text}</p>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Features;

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+const Footer = () => (
+  <footer className="bg-black py-12 text-center" id="footer">
+    <div className="container">
+      <p className="text-gray-500 text-sm">
+        &copy; {new Date().getFullYear()} Fab Distro. All rights reserved.
+      </p>
+      <nav aria-label="Footer navigation" className="mt-4">
+        <a href="#features" className="mx-2 hover:text-orange-400">
+          Features
+        </a>
+        <a href="#artists" className="mx-2 hover:text-orange-400">
+          Artists
+        </a>
+        <a href="#pricing" className="mx-2 hover:text-orange-400">
+          Pricing
+        </a>
+      </nav>
+    </div>
+  </footer>
+);
+
+export default Footer;

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+const Hero = () => {
+  return (
+    <section className="container py-24" id="hero">
+      <div className="grid md:grid-cols-2 items-center gap-8">
+        <motion.div initial={{ opacity: 0, y: 40 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.8 }}>
+          <h1 className="text-4xl md:text-6xl font-bold leading-tight mb-6">
+            Distribute Music <span className="text-orange-400">Worldwide</span>
+          </h1>
+          <p className="text-lg text-gray-300 mb-8">
+            Fab Distro empowers artists with seamless global distribution, real-time analytics,
+            and transparent royalty tracking.
+          </p>
+          <a href="#cta" className="bg-orange-500 text-black font-semibold px-6 py-3 rounded-md">
+            Start Releasing
+          </a>
+        </motion.div>
+        <motion.div
+          initial={{ opacity: 0, x: 60 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ delay: 0.3, duration: 0.8 }}
+          className="hidden md:block"
+        >
+          <img src="https://images.unsplash.com/photo-1511671782779-c97d3d27a1d4" alt="DJ mixing music" />
+        </motion.div>
+      </div>
+    </section>
+  );
+};
+
+export default Hero;

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+const links = [
+  { href: '#features', label: 'Features' },
+  { href: '#artists', label: 'Artists' },
+  { href: '#pricing', label: 'Pricing' },
+];
+
+const Navbar = () => {
+  return (
+    <header>
+      <nav className="container flex items-center justify-between py-4" aria-label="Main navigation">
+        <a href="#" className="text-xl font-bold">Fab Distro</a>
+        <ul className="flex gap-6" role="menubar">
+          {links.map((link, index) => (
+            <motion.li key={link.href} whileHover={{ y: -2 }}>
+              <a href={link.href} className="hover:text-orange-400" role="menuitem">
+                {link.label}
+              </a>
+            </motion.li>
+          ))}
+        </ul>
+        <a
+          href="#cta"
+          className="bg-orange-500 text-black font-semibold px-4 py-2 rounded-md focus-visible:outline focus-visible:outline-black"
+        >
+          Get Started
+        </a>
+      </nav>
+    </header>
+  );
+};
+
+export default Navbar;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './styles/global.css';
+
+const root = createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  background-color: #0b0b0e;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+export default {
+  content: ['./public/index.html', './src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        background: '#0b0b0e',
+      },
+    },
+  },
+  plugins: [],
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold Vite React app with Tailwind and Framer Motion
- implement animated hero, feature grid, artist slider, and CTA section
- add accessible navbar and footer for clear navigation

## Testing
- `npm test`
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7c39e604832aa236bc2489fdcca4